### PR TITLE
Fix wrong method used in getRateById

### DIFF
--- a/src/Traits/ShippingRates.php
+++ b/src/Traits/ShippingRates.php
@@ -94,7 +94,7 @@ trait ShippingRates
         array|ShipEngineConfig|null $config = null,
     ): array|ShipmentRate {
         $config = $this->config->merge($config);
-        $response = ShipEngineClient::post(
+        $response = ShipEngineClient::get(
             "rates/$rate_id",
             $config,
         );


### PR DESCRIPTION
## Description

As per the shipengine documentation it is a get request and not POST

## Release Notes

Replaced the getRateById method from POST to GET

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Chore (mundane code change)
- [ ] Maintenance (clean up)

## Checklist

- [x] Unit tests pass locally
- [ ] Added tests to code that was updated or edited
- [x] Updated/added documentation
